### PR TITLE
Add basic Fabric mod skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Gradle
+.gradle/
+build/
+
+# IDEs
+.idea/
+*.iml
+
+# misc
+out/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# minecraftmod
+# Fabric Mod Example
+
+This project contains a minimal Fabric mod setup targeting Minecraft **1.21.5**. The mod logs a message when the server or client starts.
+
+## Building
+
+1. Ensure you have JDK 17 installed.
+2. Run `./gradlew build` to compile the mod and generate a JAR in `build/libs`.
+
+## Running on a Server
+
+Copy the generated JAR into the `mods` folder of a Fabric-enabled server that is running Minecraft 1.21.5.

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+    id 'fabric-loom' version '1.5-SNAPSHOT'
+    id 'maven-publish'
+}
+
+sourceCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_17
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    minecraft "com.mojang:minecraft:1.21.5"
+    mappings "net.fabricmc:yarn:1.21.5+build.1:v2"
+    modImplementation "net.fabricmc:fabric-loader:0.15.0"
+    modImplementation "net.fabricmc.fabric-api:fabric-api:0.87.0+1.21.5"
+}
+
+loom {
+    // ensures mod runs on server and client
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx2G
+org.gradle.daemon=true
+org.gradle.parallel=true

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'fabricmod'

--- a/src/main/java/com/example/fabricmod/ExampleMod.java
+++ b/src/main/java/com/example/fabricmod/ExampleMod.java
@@ -1,0 +1,15 @@
+package com.example.fabricmod;
+
+import net.fabricmc.api.ModInitializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ExampleMod implements ModInitializer {
+    public static final String MOD_ID = "fabricmod";
+    public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
+
+    @Override
+    public void onInitialize() {
+        LOGGER.info("Hello from ExampleMod!");
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": 1,
+  "id": "fabricmod",
+  "version": "1.0.0",
+  "name": "Fabric Mod Example",
+  "description": "A simple Fabric mod that works on servers.",
+  "authors": ["Codex"],
+  "contact": {
+    "sources": "https://example.com"
+  },
+  "license": "MIT",
+  "environment": "*",
+  "entrypoints": {
+    "main": [
+      "com.example.fabricmod.ExampleMod"
+    ]
+  },
+  "depends": {
+    "fabricloader": ">=0.15.0",
+    "minecraft": "1.21.5",
+    "java": ">=17"
+  }
+}


### PR DESCRIPTION
## Summary
- set up minimal Fabric mod for Minecraft 1.21.5
- add example entrypoint that logs a startup message
- provide Fabric configuration files and build script
- update README with build and server usage instructions

## Testing
- `gradle wrapper` *(fails: Plugin [id: 'fabric-loom'] was not found)*
- `gradle build` *(fails: Plugin [id: 'fabric-loom'] was not found)*


------
https://chatgpt.com/codex/tasks/task_e_6842de6d8ef4832783dc9266cc38786d